### PR TITLE
fix responsive image `sizes`, SectionListItem images consistent aspect ratio and size

### DIFF
--- a/src/components/ImageList.js
+++ b/src/components/ImageList.js
@@ -485,7 +485,7 @@ class ImageList extends Component {
                   alt = '',
                 } = image
 
-                let sizes = isExpanded || mobileWidth ? '' : '200w'
+                let sizes = isExpanded || mobileWidth ? '' : '200px'
 
                 const onMouseEnter = isExpanded
                   ? null

--- a/src/components/SectionItemList.js
+++ b/src/components/SectionItemList.js
@@ -6,6 +6,7 @@ import cx from 'classnames'
 import {
   sansfont,
   baseUl,
+  breakpoint1,
   breakpoint2,
   breakpoint3,
 } from '../layouts/emotion-base'
@@ -61,8 +62,9 @@ const List = styled.ul`
 `
 
 const ListItem = styled.li`
-  margin: 0 48px 64px 0;
+  margin: 0 44px 64px 0;
   width: 320px;
+  height: 268px;
 
   & a {
     color: inherit;
@@ -78,33 +80,23 @@ const ListItem = styled.li`
     background-color: #eee;
     margin: 0;
     padding: 0;
-    max-width: 320px;
-    max-height: 280px;
+    width: 100%;
+    height: 100%;
+    min-width: 100%;
+    min-height: 100%;
+    object-fit: cover;
   }
 
-  &.no-image img {
-    min-width: 320px;
-    min-height: 200px;
-  }
-
-  @media (${breakpoint2}) {
+  @media (${breakpoint1}) {
     width: 240px;
-    margin: 0 40px 64px 0;
-
-    & img {
-      max-width: 240px;
-      max-height: 200px;
-    }
-
-    &.no-image img {
-      min-width: 240px;
-      min-height: 150px;
-    }
+    height: 200px;
+    margin: 0 20px 64px 0;
   }
 
   @media (${breakpoint3}) {
     margin: 0 0 32px 0;
     width: auto;
+    height: auto;
     min-width: 50%;
 
     &.full-width-mobile {
@@ -158,7 +150,6 @@ const SectionItemList = ({ sections, items, fullWidthMobile = true }) => {
               <ListItem
                 key={i}
                 className={cx({
-                  'no-image': !image,
                   'full-width-mobile': fullWidthMobile,
                 })}
               >

--- a/src/components/SectionItemList.js
+++ b/src/components/SectionItemList.js
@@ -157,7 +157,7 @@ const SectionItemList = ({ sections, items, fullWidthMobile = true }) => {
                   <img
                     src={imageLargePath(image)}
                     srcSet={imageSrcSet(image)}
-                    sizes={'400w'}
+                    sizes={`320px, (${breakpoint1}): 240px`}
                     alt={alt}
                   />
                   <ItemTitle>

--- a/src/components/SimpleImageList.js
+++ b/src/components/SimpleImageList.js
@@ -64,7 +64,7 @@ class SimpleImageList extends Component {
   }
 
   render() {
-    const { images = [], sizes = `50vw, (${breakpoint3}): 300px` } = this.props
+    const { images = [], sizes = `400px, (${breakpoint3}): 300px` } = this.props
 
     const { fullscreenImageIndex } = this.state
     const fullscreenImage = images[fullscreenImageIndex]

--- a/src/pages/info.js
+++ b/src/pages/info.js
@@ -158,7 +158,9 @@ const Info = ({ data }) => {
             </SectionListItem>
           </SectionList>
           <MailingListSignup>
-            <a href={mailingList} target="_blank">Sign Up For Mailing List</a>
+            <a href={mailingList} target="_blank">
+              Sign Up For Mailing List
+            </a>
           </MailingListSignup>
 
           {images.length > 0 && (

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -8,10 +8,13 @@ export const imageSrcSet = image => {
   if (!image || !image.resized) {
     return ''
   }
-  const resized = image.resized.map(
-    ({ file, width }) => `${imageFilepath(file)} ${width}w`
-  )
+
+  const resized = image.resized
+    .sort((a, b) => a.width - b.width)
+    .map(({ file, width }) => `${imageFilepath(file)} ${width}w`)
+
   const large = `${imageLargePath(image)} ${image.width}w`
+
   return resized.concat([large]).join(', ')
 }
 


### PR DESCRIPTION
@r1b the reason that large images were still being loaded was a stupid `w` vs `px` description in the `img.sizes` prop. I have a branch where `gatsby-image` is in progress though and think it is a nice-to-have that I might do on my own time / depending on how this meeting goes.