### PR TITLE
feature: fix admin images rendering bug

### DIFF
--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: computer-lab/salon94design.com
-  branch: r1b-netlify-latest
+  branch: master
 
 media_folder: static/images
 public_folder: /images

--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -4,7 +4,7 @@ backend:
   branch: master
 
 media_folder: static/images
-public_folder: images
+public_folder: /images
 
 collections:
   - name: designer

--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -4,7 +4,7 @@ backend:
   branch: master
 
 media_folder: static/images
-public_folder: public/static/images
+public_folder: images
 
 collections:
   - name: designer

--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: computer-lab/salon94design.com
-  branch: master
+  branch: r1b-netlify-latest
 
 media_folder: static/images
 public_folder: /images

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Salon94 Design Administration</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~1.0.3/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~0.5/dist/cms.css" />
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@~1.0.3/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@~0.5/dist/cms.js"></script>
 </body>
 </html>

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Salon94 Design Administration</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~1.3/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~1.0.3/dist/cms.css" />
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@~1.3/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@~1.0.3/dist/cms.js"></script>
 </body>
 </html>

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Salon94 Design Administration</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~0.5/dist/cms.css" />
+  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@~1.3/dist/cms.css" />
 
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@~0.5/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@~1.3/dist/cms.js"></script>
 </body>
 </html>

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -313,7 +313,7 @@ async function hydrateImage(image) {
     return null
   }
 
-  const localFilename = path.resolve(image.file.replace('/public/', ''))
+  const localFilename = path.resolve(path.join('static/', image.file))
 
   const images = await readdirAbsolute(path.dirname(localFilename))
   const resizedImages = images.filter(n => n !== localFilename)

--- a/src/data/designers/anton-alvarez.yml
+++ b/src/data/designers/anton-alvarez.yml
@@ -7,7 +7,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/anton-alvarez/the-thread-wrapping-machine-bench-271115-2015-S1Y43ji3b/large.jpg
+          /images/works/anton-alvarez/the-thread-wrapping-machine-bench-271115-2015-S1Y43ji3b/large.jpg
     medium: >-
       polyester thread, fabric, pva glue, color pigment, mdf, plywood, osb,
       wood, plastic, metal
@@ -26,7 +26,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/anton-alvarez/the-thread-wrapping-machine-chair-090415-SkB1ch00-/large.jpg
+          /images/works/anton-alvarez/the-thread-wrapping-machine-chair-090415-SkB1ch00-/large.jpg
     medium: >-
       Polyester thread, fabric, fake-fur, pva glue, color pigment, mdf, plywood,
       osb, wood, plastic and metal
@@ -40,7 +40,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/anton-alvarez/z-0308172026-HJgBk920Rb/large.jpg
+          /images/works/anton-alvarez/z-0308172026-HJgBk920Rb/large.jpg
     medium: glazed stoneware
     slug: z-0308172026
     tags:
@@ -51,7 +51,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/anton-alvarez/the-thread-wrapping-machine-untitled-280415-HJZbb4ZJG/large.jpg
+          /images/works/anton-alvarez/the-thread-wrapping-machine-untitled-280415-HJZbb4ZJG/large.jpg
     medium: >-
       polyester thread, fabric, pva glue, color pigment, mdf, plywood, osb,
       wood, plastic and metal

--- a/src/data/designers/dozie-kanu.yml
+++ b/src/data/designers/dozie-kanu.yml
@@ -13,7 +13,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/dozie-kanu/bench-on-84s-HkxKVhji2b/large.jpg
+          /images/works/dozie-kanu/bench-on-84s-HkxKVhji2b/large.jpg
     medium: 'poured concrete, steel '
     projects:
       - slug: midtown-lever-house

--- a/src/data/designers/gaetano-pesce.yml
+++ b/src/data/designers/gaetano-pesce.yml
@@ -29,7 +29,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/gaetano-pesce/puglia-cabinet-ByFkIRyyG/large.jpg
+          /images/works/gaetano-pesce/puglia-cabinet-ByFkIRyyG/large.jpg
     medium: 'wood, papier maché'
     projects:
       - slug: design-miami-2016-pesce
@@ -42,7 +42,7 @@ works:
     edition: Unique
     images:
       - file: >-
-          /public/static/images/works/gaetano-pesce/horse-cabinet-ByxFy8AkJz/large.jpg
+          /images/works/gaetano-pesce/horse-cabinet-ByxFy8AkJz/large.jpg
     medium: 'laminated plywood, gold leaf doors'
     projects:
       - slug: design-miami-2016-pesce
@@ -55,7 +55,7 @@ works:
     edition: Unique
     images:
       - file: >-
-          /public/static/images/works/gaetano-pesce/rug-wall-lamp-SJ7iLAyyf/large.jpg
+          /images/works/gaetano-pesce/rug-wall-lamp-SJ7iLAyyf/large.jpg
     medium: 'polyurethane resin and steel '
     projects:
       - slug: ghost-dog
@@ -68,7 +68,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/gaetano-pesce/mini-stracci-vases-Bks28kgJG/large.jpg
+          /images/works/gaetano-pesce/mini-stracci-vases-Bks28kgJG/large.jpg
     projects:
       - slug: design-miami-2016-pesce
     slug: mini-stracci-vases
@@ -80,7 +80,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/gaetano-pesce/do-you-still-love-me?-SJxi3Uyg1z/large.jpg
+          /images/works/gaetano-pesce/do-you-still-love-me?-SJxi3Uyg1z/large.jpg
     medium: polyurethane resin and metal structure
     projects:
       - slug: design-miami-2016-pesce
@@ -92,7 +92,7 @@ works:
   - dimensions: 37.4 x 61.02 x 61.02 in / 95 x 155 x 155 cm
     edition: Unique
     images:
-      - file: /public/static/images/works/gaetano-pesce/rug-lamp-rky_nflJM/large.jpg
+      - file: /images/works/gaetano-pesce/rug-lamp-rky_nflJM/large.jpg
     medium: Polyurethane resin and steel
     projects:
       - slug: ghost-dog

--- a/src/data/designers/jack-craig.yml
+++ b/src/data/designers/jack-craig.yml
@@ -15,9 +15,9 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/jack-craig/bronze-stool-ryS0Hlgkf/large.jpg
+          /images/works/jack-craig/bronze-stool-ryS0Hlgkf/large.jpg
       - file: >-
-          /public/static/images/works/jack-craig/bronze-stool-BJer0Helkf/large.jpg
+          /images/works/jack-craig/bronze-stool-BJer0Helkf/large.jpg
     medium: 'bronze, concrete'
     price: ''
     projects: []
@@ -33,7 +33,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/jack-craig/large-marble-table-lamp-rJmt4nsj3Z/large.jpg
+          /images/works/jack-craig/large-marble-table-lamp-rJmt4nsj3Z/large.jpg
     medium: 'bronze, marble'
     price: ''
     projects:
@@ -48,9 +48,9 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/jack-craig/dripped-bronze-shelf-rkKXM1g1z/large.jpg
+          /images/works/jack-craig/dripped-bronze-shelf-rkKXM1g1z/large.jpg
       - file: >-
-          /public/static/images/works/jack-craig/dripped-bronze-shelf-HygF7fJe1f/large.jpg
+          /images/works/jack-craig/dripped-bronze-shelf-HygF7fJe1f/large.jpg
     medium: 'bronze, concrete'
     slug: dripped-bronze-shelf
     tags:

--- a/src/data/designers/jay-sae-jung-oh.yml
+++ b/src/data/designers/jay-sae-jung-oh.yml
@@ -8,11 +8,11 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-S14FN3is3Z/large.jpg
+          /images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-S14FN3is3Z/large.jpg
       - file: >-
-          /public/static/images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-SJSY42sjn-/large.jpg
+          /images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-SJSY42sjn-/large.jpg
       - file: >-
-          /public/static/images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-rk8tEhjon-/large.jpg
+          /images/works/jay-sae-jung-oh/savage-series-black-leather-sofa-rk8tEhjon-/large.jpg
     medium: 'leather cord, various plastics'
     projects: []
     slug: savage-series-black-leather-sofa
@@ -25,7 +25,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/jay-sae-jung-oh/savage-series-black-leather-chair-SkfvwTkJz/large.jpg
+          /images/works/jay-sae-jung-oh/savage-series-black-leather-chair-SkfvwTkJz/large.jpg
     medium: 'leather cord, various plastics'
     projects:
       - slug: ghost-dog

--- a/src/data/designers/kueng-caputo.yml
+++ b/src/data/designers/kueng-caputo.yml
@@ -13,7 +13,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/kueng-caputo/marble-stool-BJMryqhA0-/large.jpg
+          /images/works/kueng-caputo/marble-stool-BJMryqhA0-/large.jpg
     medium: marble
     price: ''
     projects: []
@@ -25,7 +25,7 @@ works:
   - dimensions: 16 x 13/25 x 13.25 in / 40.6 x 33.7 x 33.7 cm
     images:
       - file: >-
-          /public/static/images/works/kueng-caputo/marble-stool-white-BkyH_AkJG/large.jpg
+          /images/works/kueng-caputo/marble-stool-white-BkyH_AkJG/large.jpg
     medium: marble
     slug: marble-stool-white
     title: Marble Stool White
@@ -34,7 +34,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/kueng-caputo/sand-chair-rJifzEbJf/large.jpg
+          /images/works/kueng-caputo/sand-chair-rJifzEbJf/large.jpg
     slug: sand-chair
     tags:
       - chairs
@@ -44,7 +44,7 @@ works:
     edition: Unique
     images:
       - file: >-
-          /public/static/images/works/kueng-caputo/marble-stool-orange-rkx1ru01yG/large.jpg
+          /images/works/kueng-caputo/marble-stool-orange-rkx1ru01yG/large.jpg
     medium: marble
     slug: marble-stool-orange
     tags:

--- a/src/data/designers/kwangho-lee.yml
+++ b/src/data/designers/kwangho-lee.yml
@@ -15,9 +15,9 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/kwangho-lee/silk-bench-1-ry_t42iih-/large.jpg
+          /images/works/kwangho-lee/silk-bench-1-ry_t42iih-/large.jpg
       - file: >-
-          /public/static/images/works/kwangho-lee/silk-bench-1-B1tYNnii3b/large.jpg
+          /images/works/kwangho-lee/silk-bench-1-B1tYNnii3b/large.jpg
     medium: Silk
     price: ''
     projects:
@@ -31,7 +31,7 @@ works:
   - dimensions: 15-20 feet long (4.5-6 m long)
     images:
       - file: >-
-          /public/static/images/works/kwangho-lee/kwangho-large-nylon-bench-SyqK42oi2Z/large.jpg
+          /images/works/kwangho-lee/kwangho-large-nylon-bench-SyqK42oi2Z/large.jpg
     medium: Nylon
     price: ''
     projects:
@@ -44,9 +44,9 @@ works:
   - dimensions: Up to 8 feet (up to 2.4 m)
     images:
       - file: >-
-          /public/static/images/works/kwangho-lee/kwangho-small-pvc-bench-BkoFNnssn-/large.jpg
+          /images/works/kwangho-lee/kwangho-small-pvc-bench-BkoFNnssn-/large.jpg
       - file: >-
-          /public/static/images/works/kwangho-lee/kwangho-small-pvc-bench-S12tE2sshZ/large.jpg
+          /images/works/kwangho-lee/kwangho-small-pvc-bench-S12tE2sshZ/large.jpg
     medium: PVC
     price: ''
     projects:
@@ -60,7 +60,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/kwangho-lee/red-silk-bench-BkBeeT1yG/large.jpg
+          /images/works/kwangho-lee/red-silk-bench-BkBeeT1yG/large.jpg
     slug: red-silk-bench
     tags:
       - benches
@@ -72,7 +72,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/kwangho-lee/kwangholeechair-rJnArpJkG/large.jpg
+          /images/works/kwangho-lee/kwangholeechair-rJnArpJkG/large.jpg
     medium: PVC tubing
     projects:
       - slug: ghost-dog

--- a/src/data/designers/lucas-samaras.yml
+++ b/src/data/designers/lucas-samaras.yml
@@ -24,7 +24,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/lucas-samaras/bracelet-7-HJMovBbyz/large.jpg
+          /images/works/lucas-samaras/bracelet-7-HJMovBbyz/large.jpg
     medium: 22 karat gold
     projects:
       - slug: gold

--- a/src/data/designers/max-lamb.yml
+++ b/src/data/designers/max-lamb.yml
@@ -12,9 +12,9 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-8-HJVr1530C-/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-8-HJVr1530C-/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-8-HyHSkc3RRZ/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-8-HyHSkc3RRZ/large.jpg
     medium: 'raw and polished Tonalite granite, leather'
     projects:
       - slug: boulders-max-lamb
@@ -25,9 +25,9 @@ works:
     edition: 'Initials carved on side, unique'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-5-HyUrJ5hCR-/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-5-HyUrJ5hCR-/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-5-BJvBy5200b/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-5-BJvBy5200b/large.jpg
     medium: 'raw and polished Tonalite granite & bridle leather '
     projects:
       - slug: boulders-max-lamb
@@ -41,9 +41,9 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-9-rJ_BkqhCAZ/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-9-rJ_BkqhCAZ/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-9-BkKS1qnCAb/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-9-BkKS1qnCAb/large.jpg
     medium: 'raw and polished Tonalite granite, bridle leather '
     projects:
       - slug: boulders-max-lamb
@@ -57,7 +57,7 @@ works:
     edition: 'Unique, initials carved on bottom'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-chair-stainless-HyXlFEnij3b/large.jpg
+          /images/works/max-lamb/thermal-spray-chair-stainless-HyXlFEnij3b/large.jpg
     medium: Polystyrene and stainless steel
     price: ''
     projects:
@@ -71,9 +71,9 @@ works:
     edition: 'Unique, initials carved on bottom'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-shelf-bronze-rJ4gFVnoj3W/large.jpg
+          /images/works/max-lamb/thermal-spray-shelf-bronze-rJ4gFVnoj3W/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-shelf-bronze-HyBxYN2oo3W/large.jpg
+          /images/works/max-lamb/thermal-spray-shelf-bronze-HyBxYN2oo3W/large.jpg
     medium: Polystyrene and bronze
     price: ''
     projects:
@@ -87,9 +87,9 @@ works:
     edition: 'Unique, initials carved on bottom'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-vase-copper-H1cHJc200W/large.jpg
+          /images/works/max-lamb/thermal-spray-vase-copper-H1cHJc200W/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-vase-copper-rJjr1qn0CZ/large.jpg
+          /images/works/max-lamb/thermal-spray-vase-copper-rJjr1qn0CZ/large.jpg
     medium: 'polystyrene, copper '
     projects:
       - slug: design-miami-basel-2017
@@ -102,7 +102,7 @@ works:
     edition: 'Unique, initials carved on side'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/thermal-spray-dining-table-stainless-BJWeYNnsohb/large.jpg
+          /images/works/max-lamb/thermal-spray-dining-table-stainless-BJWeYNnsohb/large.jpg
     medium: Polystyrene and stainless steel
     price: ''
     projects:
@@ -117,9 +117,9 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-stool-9-rkkOKJgJM/large.jpg
+          /images/works/max-lamb/tonalite-boulder-stool-9-rkkOKJgJM/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-stool-9-B1eJOYylkM/large.jpg
+          /images/works/max-lamb/tonalite-boulder-stool-9-B1eJOYylkM/large.jpg
     medium: raw and polished Tonalite granite & bridle leather
     projects:
       - slug: boulders-max-lamb
@@ -133,11 +133,11 @@ works:
     edition: 'Unique, initials carved on side'
     images:
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-10-SyILEWGyz/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-10-SyILEWGyz/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-10-rylUIVbGJz/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-10-rylUIVbGJz/large.jpg
       - file: >-
-          /public/static/images/works/max-lamb/tonalite-boulder-chair-10-BJ-ILEbz1G/large.jpg
+          /images/works/max-lamb/tonalite-boulder-chair-10-BJ-ILEbz1G/large.jpg
     medium: 'raw and polished Tonalite granite, bridle leather'
     projects:
       - slug: boulders-max-lamb

--- a/src/data/designers/philippe-malouin.yml
+++ b/src/data/designers/philippe-malouin.yml
@@ -20,7 +20,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/malouin-philippe/pm-core-SJjsF31JM/large.jpg
+          /images/works/malouin-philippe/pm-core-SJjsF31JM/large.jpg
     medium: 'cast concrete, exposed aggregate'
     projects:
       - slug: design-miami-philippe-malouin-core

--- a/src/data/designers/rick-owens.yml
+++ b/src/data/designers/rick-owens.yml
@@ -14,7 +14,7 @@ works:
     dimensions: 33.86 x 22.05 x 24.8 in / 86 x 56 x 63 cm
     hero: true
     images:
-      - file: /public/static/images/works/rick-owens/stag-stool-H1PA9uiAb/large.jpg
+      - file: /images/works/rick-owens/stag-stool-H1PA9uiAb/large.jpg
     medium: 'french elm wood, moose antler'
     price: ''
     projects: []
@@ -27,7 +27,7 @@ works:
   - dimensions: '35.43 x 23.6 x 29.92 inches / 90 x 60 x 76 cm '
     images:
       - file: >-
-          /public/static/images/works/rick-owens/tomb-stag-chair-SJnSyq3A0b/large.jpg
+          /images/works/rick-owens/tomb-stag-chair-SJnSyq3A0b/large.jpg
     medium: 'raw plywood, moose antler'
     slug: tomb-stag-chair
     tags:

--- a/src/data/designers/thomas-barger.yml
+++ b/src/data/designers/thomas-barger.yml
@@ -14,7 +14,7 @@ works:
     hero: false
     images:
       - file: >-
-          /public/static/images/works/thomas-barger/underwear-armoire-HydlYN3js3Z/large.jpg
+          /images/works/thomas-barger/underwear-armoire-HydlYN3js3Z/large.jpg
     medium: 'paper pulp, plywood, styrofoam, cardboard'
     price: ''
     projects:
@@ -29,7 +29,7 @@ works:
     hero: true
     images:
       - file: >-
-          /public/static/images/works/thomas-barger/sorting-laundry-for-a-family-of-5-HkQi_F1kM/large.jpg
+          /images/works/thomas-barger/sorting-laundry-for-a-family-of-5-HkQi_F1kM/large.jpg
     medium: 'paper pulp, carpet '
     projects:
       - slug: midtown-lever-house
@@ -42,7 +42,7 @@ works:
   - dimensions: 32.5 x 22 x 22 inches / 82.6 x 55.9 x 55.9 cm
     images:
       - file: >-
-          /public/static/images/works/thomas-barger/aleksandr-rodchenko-snack-chair-with-harness-rJyxSyqhAR-/large.jpg
+          /images/works/thomas-barger/aleksandr-rodchenko-snack-chair-with-harness-rJyxSyqhAR-/large.jpg
     medium: 'Paper pulp, cardboard, Styrofoam, and plywood'
     projects:
       - slug: ghost-dog
@@ -54,7 +54,7 @@ works:
   - hero: false
     images:
       - file: >-
-          /public/static/images/works/thomas-barger/underwear-armoire-3-HJfbTTJyG/large.jpg
+          /images/works/thomas-barger/underwear-armoire-3-HJfbTTJyG/large.jpg
     projects:
       - slug: ghost-dog
     slug: underwear-armoire-3

--- a/src/data/info/default.yml
+++ b/src/data/info/default.yml
@@ -1,4 +1,4 @@
-hero: /public/static/images/pesce image.jpg
+hero: /images/pesce image.jpg
 staff:
   - email: jeanne@salon94design.com
     name: Jeanne Greenberg Rohatyn

--- a/src/data/landing-page/default.yml
+++ b/src/data/landing-page/default.yml
@@ -1,2 +1,2 @@
-splashImage: /public/static/images/ezgif.com-optimize.gif
+splashImage: /images/ezgif.com-optimize.gif
 featuredProjectSlug: boulders-max-lamb

--- a/src/data/projects/boulders-max-lamb.yml
+++ b/src/data/projects/boulders-max-lamb.yml
@@ -72,7 +72,7 @@ description: >-
   maxime@salon94design.com. For press inquiries, please contact Sophie Wise at
   sophie@companyagenda.com.
 images:
-  - file: /public/static/images/projects/boulders-max-lamb/Hysbqxzkz/large.jpg
+  - file: /images/projects/boulders-max-lamb/Hysbqxzkz/large.jpg
     hero: true
 video:
   caption: ''

--- a/src/data/projects/design-miami-basel-2017.yml
+++ b/src/data/projects/design-miami-basel-2017.yml
@@ -11,14 +11,14 @@ description: |-
 
   Lucas Samaras – Gold Jewelry
 images:
-  - file: /public/static/images/projects/design-miami-basel-2017/B190OjO1M/large.jpg
+  - file: /images/projects/design-miami-basel-2017/B190OjO1M/large.jpg
   - file: >-
-      /public/static/images/projects/design-miami-basel-2017/Hyx5CusOyG/large.jpg
+      /images/projects/design-miami-basel-2017/Hyx5CusOyG/large.jpg
   - file: >-
-      /public/static/images/projects/design-miami-basel-2017/ryb9ROiuyf/large.jpg
+      /images/projects/design-miami-basel-2017/ryb9ROiuyf/large.jpg
     hero: true
   - file: >-
-      /public/static/images/projects/design-miami-basel-2017/HkGcRds_kM/large.jpg
+      /images/projects/design-miami-basel-2017/HkGcRds_kM/large.jpg
 video:
   caption: ''
   vimeoId: ''

--- a/src/data/projects/design-miami-pesce.yml
+++ b/src/data/projects/design-miami-pesce.yml
@@ -21,16 +21,16 @@ description: >-
   his 2006 Horse Cabinet.
 images:
   - caption: Puglia Cabinet
-    file: /public/static/images/projects/design-miami-pesce/rkzvfj3RCZ/large.jpg
+    file: /images/projects/design-miami-pesce/rkzvfj3RCZ/large.jpg
   - caption: Do You Still Love Me? Cabinet
-    file: /public/static/images/projects/design-miami-pesce/S1xvfi3C0-/large.jpg
+    file: /images/projects/design-miami-pesce/S1xvfi3C0-/large.jpg
     hero: false
-  - file: /public/static/images/projects/design-miami-pesce/SJilCAJkM/large.jpg
+  - file: /images/projects/design-miami-pesce/SJilCAJkM/large.jpg
   - caption: Horse Cabinet
-    file: /public/static/images/projects/design-miami-pesce/rkZwfi3CC-/large.jpg
-  - file: /public/static/images/projects/design-miami-pesce/SyJ97TJkz/large.jpg
+    file: /images/projects/design-miami-pesce/rkZwfi3CC-/large.jpg
+  - file: /images/projects/design-miami-pesce/SyJ97TJkz/large.jpg
     hero: false
-  - file: /public/static/images/projects/design-miami-pesce/r1xjeAAJkM/large.jpg
+  - file: /images/projects/design-miami-pesce/r1xjeAAJkM/large.jpg
     hero: true
 video:
   caption: ''

--- a/src/data/projects/design-miami-philippe-malouin-core.yml
+++ b/src/data/projects/design-miami-philippe-malouin-core.yml
@@ -15,11 +15,11 @@ description: >-
   multidisciplinary interior design company, POST- OFFICE.
 images:
   - file: >-
-      /public/static/images/projects/design-miami-philippe-malouin-core/BJlaVaACZ/large.jpg
+      /images/projects/design-miami-philippe-malouin-core/BJlaVaACZ/large.jpg
     hero: true
   - file: >-
-      /public/static/images/projects/design-miami-philippe-malouin-core/H1lxTETCR-/large.jpg
+      /images/projects/design-miami-philippe-malouin-core/H1lxTETCR-/large.jpg
   - file: >-
-      /public/static/images/projects/design-miami-philippe-malouin-core/HJblaN6C0-/large.jpg
+      /images/projects/design-miami-philippe-malouin-core/HJblaN6C0-/large.jpg
 video:
   vimeoId: ''

--- a/src/data/projects/ghost-dog.yml
+++ b/src/data/projects/ghost-dog.yml
@@ -75,11 +75,11 @@ description: >-
   and figuration in taking the shape of a clown.
 images:
   - caption: 'Gaetano Pesce, Jay Sae Jung Oh, Kwangho Lee, Jack Craig, Thomas Barger'
-    file: /public/static/images/projects/ghost-dog/ryHHJPIpZ/large.jpg
-  - file: /public/static/images/projects/ghost-dog/HyxSHJPIaZ/large.jpg
-  - file: /public/static/images/projects/ghost-dog/S1HqraJyG/large.jpg
-  - file: /public/static/images/projects/ghost-dog/SkgrlgaJyf/large.jpg
-  - file: /public/static/images/projects/ghost-dog/BJlrqHp1kM/large.jpg
+    file: /images/projects/ghost-dog/ryHHJPIpZ/large.jpg
+  - file: /images/projects/ghost-dog/HyxSHJPIaZ/large.jpg
+  - file: /images/projects/ghost-dog/S1HqraJyG/large.jpg
+  - file: /images/projects/ghost-dog/SkgrlgaJyf/large.jpg
+  - file: /images/projects/ghost-dog/BJlrqHp1kM/large.jpg
 video:
   caption: ''
   vimeoId: ''

--- a/src/data/projects/gold.yml
+++ b/src/data/projects/gold.yml
@@ -57,9 +57,9 @@ description: >-
   information, please contact Samuel Zients at sam@salon94design.com. For press
   inquiries, please contact Sophie Wise at sophie@companyagenda.com.
 images:
-  - file: /public/static/images/projects/gold/BklW_2h11z/large.jpg
+  - file: /images/projects/gold/BklW_2h11z/large.jpg
     hero: true
-  - file: /public/static/images/projects/gold/H1WW_22yJf/large.jpg
+  - file: /images/projects/gold/H1WW_22yJf/large.jpg
 video:
   caption: ''
   vimeoId: ''

--- a/src/data/projects/midtown-lever-house.yml
+++ b/src/data/projects/midtown-lever-house.yml
@@ -112,11 +112,11 @@ description: >-
   Kung at victoria.kung@suttonpr.com. For all other inquiries about _MIDTOWN_,
   please contact  info@salon94design.com.
 images:
-  - file: /public/static/images/projects/midtown-lever-house/BkWjgARJkz/large.jpg
+  - file: /images/projects/midtown-lever-house/BkWjgARJkz/large.jpg
     hero: true
-  - file: /public/static/images/projects/midtown-lever-house/ry3TLWAAZ/large.jpg
-  - file: /public/static/images/projects/midtown-lever-house/rJx3aLbR0-/large.jpg
-  - file: /public/static/images/projects/midtown-lever-house/HyH4D-CAW/large.jpg
+  - file: /images/projects/midtown-lever-house/ry3TLWAAZ/large.jpg
+  - file: /images/projects/midtown-lever-house/rJx3aLbR0-/large.jpg
+  - file: /images/projects/midtown-lever-house/HyH4D-CAW/large.jpg
 video:
   caption: 'FLUCT+ X PERFORMA NYC  '
   vimeoId: '243903238'

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -1,5 +1,5 @@
 export const imageFilepath = file =>
-  `__PATH_PREFIX__${file}`
+  __PATH_PREFIX__ + `${file}`
 
 export const imageLargePath = image =>
   image ? imageFilepath(image.file) : null

--- a/src/util/image.js
+++ b/src/util/image.js
@@ -1,5 +1,5 @@
 export const imageFilepath = file =>
-  __PATH_PREFIX__ + `${file.replace('/public/static', '')}`
+  `__PATH_PREFIX__${file}`
 
 export const imageLargePath = image =>
   image ? imageFilepath(image.file) : null

--- a/transformer/images.js
+++ b/transformer/images.js
@@ -176,23 +176,17 @@ async function updateInfo (info, processedImages) {
 async function getProcessedImageData (image, processedImageItem) {
   const { newImage } = processedImageItem
   return Object.assign({}, image, {
-    file: imageDataFilename(newImage)
+    file: newImage
   })
 }
 
 async function getImageData (filename) {
   const { width, height } = await sharp(filename).metadata()
   return {
-    file: imageDataFilename(filename),
+    file: filename,
     width,
     height
   }
-}
-
-function imageDataFilename (filename) {
-  // References to images in the data need to be prefixed with /public/static/ to show up in the CMS
-  const prefix = 'images/'
-  return path.join('/public/static', filename.substr(filename.indexOf(prefix)))
 }
 
 function workImageFilename (designer, work, image) {

--- a/transformer/images.js
+++ b/transformer/images.js
@@ -176,17 +176,22 @@ async function updateInfo (info, processedImages) {
 async function getProcessedImageData (image, processedImageItem) {
   const { newImage } = processedImageItem
   return Object.assign({}, image, {
-    file: newImage
+    file: imageDataFilename(newImage)
   })
 }
 
 async function getImageData (filename) {
   const { width, height } = await sharp(filename).metadata()
   return {
-    file: filename,
+    file: imageDataFilename(filename),
     width,
     height
   }
+}
+
+function imageDataFilename (filename) {
+  const prefix = '/images/';
+  return filename.substr(filename.indexOf(prefix))
 }
 
 function workImageFilename (designer, work, image) {


### PR DESCRIPTION
Currently on salon94design.com/admin/ the images don't show up in the admin UI - this is because we are stripping /public/static/ from the image paths but the admin UI does not. I fixed the path handling so that the images can just be relative starting with `/images/` - now they will work in both contexts.

I also bumped the admin UI to the latest version to check it out - you can look at it here:
https://5a4ad3b3a6188f3267d1b62a--tank-commander-melody-70755.netlify.com/

Note that the images fix will **not** work in the preview since the preview loads the data from the master branch - it will ultimately work in prod.

@kevin-roark check out the new UI and let me know what you think - if we don't want to bump the CMS version i can just take that part in and merge the bugfix only.