### PR TITLE
bugfix: temporarily neuter Represented / Also Available display

### DIFF
--- a/src/pages/designers.js
+++ b/src/pages/designers.js
@@ -16,6 +16,9 @@ export default function Designers({ data }) {
   let designers = allDesignersYaml.edges.map(edge => edge.node)
   designers.sort(byLastName)
 
+/*
+  XXX : Removing this for demo - need to come up with a way to style this
+
   const designersByStatus = {}
   designers.forEach(d => {
     if (!designersByStatus[d.status]) {
@@ -40,6 +43,11 @@ export default function Designers({ data }) {
 
     return { title, items }
   })
+*/
+  const listSections = [{
+    title: null,
+    items: designers.map(designer => ({ title: designer.title, link: designerLink(designer.slug)}))
+  }];
 
   return (
     <div>


### PR DESCRIPTION
@kevin-roark I'm going to temporarily disable the distinction between `Available` and `Represented` designers - right now it looks kinda weird with the `SectionTitle` aligned left