### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -15,7 +15,7 @@ collections:
     format: yaml
     fields:
       - name: slug
-        label: Slug (for url - all lowercase, no spaces or special characters)
+        label: Slug (for url - unique, all lowercase, no spaces or special characters, no leading / trailing whitespace)
         widget: string
       - name: title
         label: Name
@@ -46,7 +46,7 @@ collections:
             label: Title
             widget: string
           - name: slug
-            label: Slug (for url - all lowercase, no spaces or special characters)
+            label: Slug (for url - unique, all lowercase, no spaces or special characters, no leading / trailing whitespace)
             widget: string
           - name: when
             label: Year
@@ -63,7 +63,7 @@ collections:
                 searchFields: [slug, title]
                 valueField: slug
           - name: tags
-            label: "Tags — F: beds, benches, chairs, outdoor, seating, storage, tables | L: lighting | M: all other tags (other, ceramics, fashion, etc)."
+            label: "ceramics, jewlery, lighting, other, seating, storage, tables - any tag can be added, all lowercase"
             widget: list
             default: []
           - name: hero
@@ -121,7 +121,7 @@ collections:
     format: yaml
     fields:
       - name: slug
-        label: Slug (for url - all lowercase, no spaces or special characters)
+        label: Slug (for url - unique, all lowercase, no spaces or special characters, no leading / trailing whitespace)
         widget: string
       - name: title
         label: Title

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -113,6 +113,15 @@ search for the object you want to edit instead of finding it in the collection
 grid. In this case you can use the search bar in the top menu bar. The search
 bar is case-insensitive and will return any matching object in a grid.
 
+### Adding images
+
+**XXX may be subject to change**
+
+Uploaded images should have either a 4:3 or 3:4 aspect ratio with the work
+centered in the image. Wide images are preferred - tall images may be cut off
+depending on their height. Images should be no bigger than 1MB. Any image format
+is supported, however, ultimately the images will be converted to JPEGs.
+
 ### Verifying your changes
 
 Once you click the *Save* button on a new object, the following process takes

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -238,8 +238,14 @@ exports.onCreateNode = async ({ node, boundActionCreators }) => {
 
   const hydrateImages = async (node, nameProvider, addDummyImages = false) => {
     if (node.images) {
-      node.hydratedImages = await Promise.all(node.images.map((image, idx) => hydrateImage(image, idx, nameProvider)))
+      node.hydratedImages = await (
+        Promise.all(
+          node.images
+            .filter(image => image.file)
+            .map((image, idx) => hydrateImage(image, idx, nameProvider))
+        )
         .filter(item => !!item)
+      )
     }
 
     // necessary for some graphql queries

--- a/src/templates/designer.js
+++ b/src/templates/designer.js
@@ -113,9 +113,6 @@ const DesignerTemplate = ({ data, pathContext }) => {
       })
     )
 
-  // Reverse-when work image sort
-  images.sort((a, b) => -1 * a.work.when.localeCompare(b.work.when));
-
   const allImages = [{
     project: null,
     images

--- a/transformer/purify.js
+++ b/transformer/purify.js
@@ -35,7 +35,7 @@ async function processDesigners () {
   const impureDesigners = designers.filter(designer =>
     designer.slug !== slugifyLower(designer.slug) ||
     (designer.works || []).filter(work =>
-      work && work.slug !== slugifyLower(work.slug)
+      work.slug && work.slug !== slugifyLower(work.slug)
     ).length > 0
   )
 

--- a/transformer/purify.js
+++ b/transformer/purify.js
@@ -35,7 +35,7 @@ async function processDesigners () {
   const impureDesigners = designers.filter(designer =>
     designer.slug !== slugifyLower(designer.slug) ||
     (designer.works || []).filter(work =>
-      work.slug !== slugifyLower(work.slug)
+      work && work.slug !== slugifyLower(work.slug)
     ).length > 0
   )
 


### PR DESCRIPTION
* Fixes crash on missing `when` field - i think it makes sense for them to determine the sort order of the works by re-ordering them in the CMS (to put works of the same series together for example)
* Fixes crash when empty image encountered in `hydrateImages`
* Fixes crash on missing work in `transformer/purify.js`
* Documentation updates