### PR TITLE
display dates in exhibition list

### DIFF
--- a/contrib/config.yml
+++ b/contrib/config.yml
@@ -134,10 +134,13 @@ collections:
           - Art Fair
         default: Exhibition
       - name: when
-        label: When
+        label: When (text description of when project is open)
         widget: string
-      - name: date
+      - name: start_date
         label: Start Date (for sorting, use YYYY-MM-DD format)
+        widget: text
+      - name: end_date
+        label: End Date (for sorting, use YYYY-MM-DD format)
         widget: text
       - name: designers
         label: Designers

--- a/package-lock.json
+++ b/package-lock.json
@@ -5010,7 +5010,7 @@
         "mime": "1.4.1",
         "mitt": "1.1.2",
         "mkdirp": "0.5.1",
-        "moment": "2.19.1",
+        "moment": "2.21.0",
         "node-libs-browser": "2.0.0",
         "normalize-path": "2.1.1",
         "null-loader": "0.1.1",
@@ -6499,7 +6499,7 @@
         "hoek": "4.2.0",
         "isemail": "2.2.1",
         "items": "2.1.1",
-        "moment": "2.19.1",
+        "moment": "2.21.0",
         "topo": "2.0.2"
       }
     },
@@ -7437,9 +7437,9 @@
       }
     },
     "moment": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "mri": {
       "version": "1.1.0",
@@ -15621,7 +15621,7 @@
             "hoek": "4.2.0",
             "isemail": "2.2.1",
             "items": "2.1.1",
-            "moment": "2.19.1",
+            "moment": "2.21.0",
             "topo": "2.0.2"
           }
         },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.flatmapdeep": "^4.10.0",
     "lodash.throttle": "^4.1.1",
+    "moment": "^2.21.0",
     "promise-retry": "^1.1.1",
     "react-scroll": "^1.5.4",
     "remark": "^8.0.0",

--- a/src/components/DesignerProjects.js
+++ b/src/components/DesignerProjects.js
@@ -25,14 +25,20 @@ const DesignerProjects = ({ projects }) => {
   }
 
   // XXX: Projects with missing or invalid dates will not be displayed
-  projects = projects.filter((p) => p.date && !isNaN((new Date(p.date)).getTime()))
+  projects = projects
+    .map(p => {
+      const start_date = p.start_date ? new Date(p.start_date) : null
+      const end_date = p.end_date ? new Date(p.end_date) : null
+      return !isNaN(start_date.getTime()) ? { ...p, start_date, end_date } : null
+    })
+    .filter(p => p != null)
 
   // Sort by reverse-date
-  projects.sort((a, b) => (new Date(b.date)).getTime() - (new Date(a.date)).getTime())
+  projects.sort((a, b) => b.start_date.getTime() - a.start_date.getTime())
 
   // Group by year
   const projectsByYear = projects.reduce((acc, project) => {
-    const year = (new Date(project.date)).getFullYear()
+    const year = project.start_date.getFullYear()
     if (!acc[year]) {
       acc[year] = [project]
     }
@@ -48,7 +54,7 @@ const DesignerProjects = ({ projects }) => {
     <Container>
       <Header2>Exhibitions</Header2>
       {descendingYears.map(year => (
-        <SimpleLinkListSection>
+        <SimpleLinkListSection key={year}>
           <Header3>{year}</Header3>
           <SimpleLinkList>
             {projectsByYear[year].map(item => (

--- a/src/components/SectionItemList.js
+++ b/src/components/SectionItemList.js
@@ -128,9 +128,9 @@ const ItemTitle = styled.div`
 `
 
 const ItemSubtitle = styled.div`
-  margin: 4px 0;
+  margin: 3px 0;
   font-size: 16px;
-  line-height: 1.2;
+  line-height: 1.4;
 `
 
 const ItemDescription = styled.div`

--- a/src/components/project-list.js
+++ b/src/components/project-list.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'gatsby-link'
 
 import SectionItemList from '../components/SectionItemList'
-import { chooseProjectImage, projectLink } from '../util'
+import { chooseProjectImage, projectLink, getProjectDateText } from '../util'
 import { CenterContainer } from '../layouts/emotion-base'
 
 function ProjectList({ allProjectsYaml, allDesignersYaml, type }) {
@@ -21,9 +21,16 @@ function ProjectList({ allProjectsYaml, allDesignersYaml, type }) {
     .filter(p => p.designers.length > 0)
 
   const listItems = projects.map(project => {
-    const subtitle = type === 'Art Fair' || project.designers.length > 3
-      ? null
-      : project.designers.map(d => d.title).join(', ')
+    let subtitle = null
+    if (type === 'Exhibition') {
+      const dateText = getProjectDateText(project)
+      subtitle = (
+        <div>
+          { project.designers.length <= 3 && <div>{project.designers.map(d => d.title).join(', ')}</div> }
+          { dateText && <div>{ dateText }</div> }
+        </div>
+      )
+    }
 
     return {
       title: project.title,

--- a/src/data/projects/boulders-max-lamb.yml
+++ b/src/data/projects/boulders-max-lamb.yml
@@ -2,7 +2,8 @@ slug: boulders-max-lamb
 title: Boulders
 type: Exhibition
 when: 'Opening November 9, 2017 6-8pm / 12 E. 94th St. New York, NY 10128'
-date: '2017-11-09'
+start_date: '2017-11-09'
+end_date: '2018-02-28'
 designers:
   - slug: max-lamb
 description: >-

--- a/src/data/projects/design-miami-2017-tom-sachs.yml
+++ b/src/data/projects/design-miami-2017-tom-sachs.yml
@@ -2,7 +2,8 @@ slug: design-miami-2017-tom-sachs
 title: Design Miami 2017 Tom Sachs
 type: Art Fair
 when: December 2017
-date: '2017-12-01'
+start_date: '2017-12-01'
+end_date: '2017-12-31'
 designers:
   - slug: tom-sachs
 description: Tom Sachs exhibition at Design Miami 2017.

--- a/src/data/projects/design-miami-basel-2017.yml
+++ b/src/data/projects/design-miami-basel-2017.yml
@@ -2,7 +2,8 @@ slug: design-miami-basel-2017
 title: 'Design Miami/Basel 2017 Max Lamb, Lucas Samaras'
 type: Art Fair
 when: June 2017
-date: '2017-06-01'
+start_date: '2017-06-01'
+end_date: '2017-06-30'
 designers:
   - slug: max-lamb
   - slug: lucas-samaras

--- a/src/data/projects/design-miami-pesce.yml
+++ b/src/data/projects/design-miami-pesce.yml
@@ -2,7 +2,8 @@ slug: design-miami-2016-pesce
 title: Design Miami 2016 Gaetano Pesce
 type: Art Fair
 when: '2016'
-date: '2016-06-01'
+start_date: '2016-06-01'
+end_date: '2016-06-30'
 designers:
   - slug: gaetano-pesce
 description: >-

--- a/src/data/projects/design-miami-philippe-malouin-core.yml
+++ b/src/data/projects/design-miami-philippe-malouin-core.yml
@@ -2,7 +2,8 @@ slug: design-miami-2017-philippe-malouin-core
 title: Design Miami 2017 Philippe Malouin
 type: Art Fair
 when: December 2017
-date: '2017-12-01'
+start_date: '2017-12-01'
+end_date: '2017-12-31'
 designers:
   - slug: philippe-malouin
 description: >-

--- a/src/data/projects/ghost-dog.yml
+++ b/src/data/projects/ghost-dog.yml
@@ -2,7 +2,8 @@ slug: ghost-dog
 title: Ghost Dog
 type: Exhibition
 when: 'March 03 – April 15, 2017'
-date: '2017-03-03'
+start_date: '2017-03-03'
+end_date: '2017-04-15'
 designers:
   - slug: thomas-barger
   - slug: gaetano-pesce

--- a/src/data/projects/gold.yml
+++ b/src/data/projects/gold.yml
@@ -2,7 +2,8 @@ slug: gold
 title: Gold
 type: Exhibition
 when: September 19–November 03
-date: '2017-09-19'
+start_date: '2017-09-19'
+end_date: '2017-11-03'
 designers:
   - slug: lucas-samaras
 description: >-

--- a/src/data/projects/growing-up.yml
+++ b/src/data/projects/growing-up.yml
@@ -2,7 +2,8 @@ slug: growing-up
 title: Growing Up
 type: Exhibition
 when: 'March 6 - March 31, 2018'
-date: '2018-03-06'
+start_date: '2018-03-06'
+end_date: '2018-03-31'
 designers:
   - slug: thomas-barger
 description: >-

--- a/src/data/projects/midtown-lever-house.yml
+++ b/src/data/projects/midtown-lever-house.yml
@@ -2,7 +2,8 @@ slug: midtown-lever-house
 title: Midtown Lever House
 type: Exhibition
 when: 'May 03 – June 09, 2017'
-date: '2017-05-03'
+start_date: '2017-05-03'
+end_date: '2017-06-09'
 designers:
   - slug: anton-alvarez
   - slug: kwangho-lee

--- a/src/layouts/emotion-base.js
+++ b/src/layouts/emotion-base.js
@@ -29,9 +29,10 @@ export const childLink = css`
     color: inherit;
     text-decoration: inherit;
 
-    &:hover,
-    &:focus {
-      border-bottom: 2px solid #000;
+    @media(${minBreakpoint3}) {
+      &:hover {
+        border-bottom: 2px solid #000;
+      }
     }
   }
 `

--- a/src/pages/exhibitions.js
+++ b/src/pages/exhibitions.js
@@ -23,7 +23,7 @@ export default function Exhibitions({ data }) {
 
 export const pageQuery = graphql`
   query ExhibitionsQuery {
-    allProjectsYaml(sort: { order: DESC, fields: [date, title] }) {
+    allProjectsYaml(sort: { order: DESC, fields: [start_date, title] }) {
       edges {
         node {
           ...projectListFields

--- a/src/pages/fairs.js
+++ b/src/pages/fairs.js
@@ -23,7 +23,7 @@ export default function ArtFairs({ data }) {
 
 export const pageQuery = graphql`
   query ArtFairsQuery {
-    allProjectsYaml(sort: { order: DESC, fields: [date, title] }) {
+    allProjectsYaml(sort: { order: DESC, fields: [start_date, title] }) {
       edges {
         node {
           ...projectListFields

--- a/src/templates/homepage.js
+++ b/src/templates/homepage.js
@@ -137,7 +137,8 @@ export const pageQuery = graphql`
         slug
         title
         type
-        date
+        start_date
+        end_date
         designers {
           slug
         }
@@ -197,7 +198,8 @@ export const pageQuery = graphql`
     description
     descriptionHtml
     when
-    date
+    start_date
+    end_date
     designers {
       slug
     }

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -88,7 +88,7 @@ const ProjectTemplate = ({ data, pathContext }) => {
   const currentTypeProjects = projects.filter(p => p.type === project.type)
 
   const projectsByYear = Array.from(
-    new Set(currentTypeProjects.map(p => p.date))
+    new Set(currentTypeProjects.map(p => p.start_date))
   )
     .sort((a, b) => Date.parse(b) - Date.parse(a)) // sort reverse-chronologically
     .map(date => {
@@ -98,7 +98,7 @@ const ProjectTemplate = ({ data, pathContext }) => {
       const year = dateYear(date)
       return {
         year,
-        projects: currentTypeProjects.filter(p => dateYear(p.date) === year),
+        projects: currentTypeProjects.filter(p => dateYear(p.start_date) === year),
       }
     })
 

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -1,0 +1,18 @@
+import moment from 'moment'
+
+export function getProjectDateText (project) {
+  const startDate = moment(project.start_date)
+  const endDate = moment(project.end_date)
+  let dateText = null
+  if (startDate.isValid() && endDate.isValid()) {
+    const equalYears = startDate.format('YYYY') === endDate.format('YYYY')
+    const startDateText = equalYears ? startDate.format('MMMM Do') : startDate.format('MMMM Do, YYYY')
+    const endDateText = endDate.format('MMMM Do, YYYY')
+    dateText = `${startDateText} – ${endDateText}`
+  }
+  else if (startDate.isValid()) {
+    dateText = startDate.format('MMMM Do, YYYY')
+  }
+
+  return dateText
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,4 +1,5 @@
 export * from './data'
+export * from './format'
 export * from './image'
 export * from './path'
 export * from './tag'


### PR DESCRIPTION
Also changes data model of projects from having a single `date` field to `start_date` and `end_date` fields to build towards Past, Present, and Future sections.

Notes:
* I left the `when` field in the projects for displaying date / info about exhibition on the exhibition page itself. That field doesn't have consistent formatting between exhibitions and different fairs, and is sometimes used to show location information, so I didn't think deleting it was the best idea, but I'm open to suggestions.
* I made up an end date for `Boulders` because I couldn't find one online. We should be sure to tell Maxime so they can update it to the correct value on their end.