### PR TITLE
Bugfix: remove double-src from imageInfo to make image src medium width (Safari Bandwidth investigation 1)

### DIFF
--- a/src/util/image.js
+++ b/src/util/image.js
@@ -68,7 +68,6 @@ export const imageInfo = image => {
   const largest = getLargestImage(image)
   return {
     src: imageMediumPath(image),
-    src: largest ? imageFilepath(largest.file) : null,
     srcSet: imageSrcSet(image),
     largeSrc: largest ? imageFilepath(largest.file) : null,
     largeSize: largest ? imageLargeSize(largest) : imageLargeSize(image),


### PR DESCRIPTION
@r1b we already determined that setting `src` to a more reasonable image width improved speed on safari and mobile safari, but it looks like we regressed on that bug by setting `src` twice there. Let's see how much this positively impacts bandwidth use, and add a polyfill or switch to `picture` if results aren't promising.